### PR TITLE
Change length of SCE20UU_Pr30b to 58mm (real)

### DIFF
--- a/kcomp.py
+++ b/kcomp.py
@@ -849,7 +849,7 @@ SCE20UU_Pr30 = {    # to print with 30x30 profiles sep_l = 60
         }
 
 SCE20UU_Pr30b = {    # to print with 30x30 profiles sep_l = 30
-        'L'          : 53.,
+        'L'          : 58., # changed from 53 to 58, bearing limit was too thin
         'W'          : 54.,
         'H'          : 41.,
         'axis_h'     : 21.,


### PR DESCRIPTION
The previous commit was about adding .gitignore file
This changes the length of SCE20UU_Pr30b, because it was too short, making
the limits of the bearing too thin