### PR TITLE
Provide correct icon path [Issue #20]

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -23,12 +23,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************/
+import os
+
 
 class MakerWorkbench (Workbench):
-    """Maker Wokbench to create objects"""
+    """Maker Workbench to create objects"""
+
+    import MakerLocator as locator
+
     #  Icon in XPM 16x16
-    Icon = "/Resources/icons/Maker_workbench_icon.svg"
-    
+    icon_path = os.path.join(locator.path(), "Resources", "icons")
+    Icon = os.path.join(icon_path, "Maker_workbench_icon.svg")
+
     # """
     # /* XPM */
     # static char * Filter_Stage_xpm[] = {
@@ -119,7 +125,7 @@ class MakerWorkbench (Workbench):
         # |                               |
         # |   List of optic models        |
         # |                               |
-        # +-------------------------------+    
+        # +-------------------------------+
 
         opticList = ["TubeLense",
                      "LCB1M_Base",
@@ -178,9 +184,9 @@ class MakerWorkbench (Workbench):
             str(QtCore.QT_TRANSLATE_NOOP("Maker", "Systems")), sysList)
         self.appendMenu(
             str(QtCore.QT_TRANSLATE_NOOP("Maker", "Functions")), modList)
-        
+
         Log('Loalding Maker Workbench... done! \n')
-    
+
     def GetClassName(self):
         return "Gui::PythonWorkbench"
 

--- a/MakerLocator.py
+++ b/MakerLocator.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# FreeCAD init script of the Filter Stage module,
+
+# ***************************************************************************
+# *   (c) David Muñoz Bernal                                                *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Lesser General Public License for more details.                   *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************/
+"Locator file for MakerWorkbench"
+
+import os
+
+
+def path():
+    return os.path.dirname(__file__)


### PR DESCRIPTION
I borrowed from the authors of other workbenches to resolves the issue of the missing icon path (#21 did not work for me).

I initially tried to use ```__file__```, but apparently that attribute is unavailable inside a class? Regardless, this seems to work and does not rely on static naming conventions for the workbench.