### PR TITLE
Correct branch name in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -6,7 +6,7 @@
   <date>2022-01-07</date> <!-- Date of the last update to the version number -->
   <maintainer email="43390350+davidmubernal@users.noreply.github.com">David Muñoz</maintainer>
   <license file="LICENSE">LGPL-3</license> <!-- Make sure you actually have this file in your Addon repo if the license requires it -->
-  <url type="repository" branch="main">https://github.com/URJCMakerGroup/MakerWorkbench</url> <!-- Don't forget to update the branch name here -->
+  <url type="repository" branch="master">https://github.com/URJCMakerGroup/MakerWorkbench</url> <!-- Don't forget to update the branch name here -->
   <url type="readme">https://github.com/URJCMakerGroup/MakerWorkbench/blob/main/README.md</url> <!-- Link to the HTML-rendered README page -->
   <icon>Resources/icons/Maker_workbench_icon.svg</icon> <!-- If you include your icon here, you don't have to submit it to the main FreeCAD repo -->
 


### PR DESCRIPTION
The name of your primary branch is "master", which should be reflected in the package.xml file. This is required for the Addon Manager to correctly display the icon and README data for this workbench.